### PR TITLE
Strip gmail's html quote properly

### DIFF
--- a/nestedquoteremover-me/src/compose.js
+++ b/nestedquoteremover-me/src/compose.js
@@ -77,12 +77,27 @@ function processHtmlBlockquotes(nodes, replyHeaderHandling, maxDepth, depth) {
     for (let node of nodes) {
         if (node.nodeType === Node.ELEMENT_NODE &&
             node.nodeName === "BLOCKQUOTE" &&
-            node.hasAttribute("type") && node.getAttribute("type") === "cite") {
+            (node.hasAttribute("type") && node.getAttribute("type") === "cite" || // regular quote
+            node.hasAttribute("class") && node.getAttribute("class") === "gmail_quote")) // gmail web interface quote
+        {
             if (depth > maxDepth) {
                 node.remove();
             } else {
                 processHtmlBlockquotes(node.childNodes, replyHeaderHandling, maxDepth, depth + 1);
             }
+        }
+
+        else if (node.nodeType === Node.ELEMENT_NODE &&
+            node.nodeName === "DIV" &&
+            node.hasAttribute("class") && node.getAttribute("class") === "gmail_quote") // gmail web interface pre-quote div
+        {
+            processHtmlBlockquotes(node.childNodes, replyHeaderHandling, maxDepth, depth);
+        }
+
+        else if (node.nodeType === Node.ELEMENT_NODE &&
+            node.nodeName === "DIV") // generic div
+        {
+            processHtmlBlockquotes(node.childNodes, replyHeaderHandling, maxDepth, depth);
         }
 
         if (replyHeaderHandling.remove && depth > maxDepth) {


### PR DESCRIPTION
Gmail web interface uses not-totally-standard quotes: div (or blockquote) with class=gmail_quote, instead of blockquote with type=cite.

Without this fix, NestedQuote Remover can't clean anything in gmail correspondence. Without "generic div hander" cite depth is computed incorrectly, so don't remove it (it works for depth=1 but not for others).